### PR TITLE
Mesh Bind Selection Crash Fix

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1207,6 +1207,9 @@ fn select_bone(
     if idx == usize::MAX {
         sel.bone_idx = usize::MAX;
         sel.bone_ids = vec![];
+        sel.bind = -1;
+        edit_mode.setting_ik_target = false;
+        edit_mode.setting_bind_bone = false;
         return;
     }
 
@@ -1230,8 +1233,11 @@ fn select_bone(
     if edit_mode.setting_bind_bone {
         let bone_idx = sel.bind as usize;
         let id = armature.bones[idx].id;
-        let bind = &mut armature.sel_bone_mut(&sel).unwrap().binds[bone_idx];
-        bind.bone_id = id;
+        if let Some(bone) = armature.sel_bone_mut(&sel) {
+            if let Some(bind) = bone.binds.get_mut(bone_idx) {
+                bind.bone_id = id;
+            }
+        }
         edit_mode.setting_bind_bone = false;
         return;
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1406,14 +1406,16 @@ pub fn bone_vertices(
             1.
         };
         let idx = selections.bind;
-        let verts: Vec<i32>;
-        if idx == -1 {
-            verts = vec![];
+        let verts: Vec<i32> = if idx == -1 {
+            vec![]
+        } else if let Some(bind) = armature
+            .sel_bone(&sel)
+            .and_then(|selected| selected.binds.get(idx as usize))
+        {
+            bind.verts.iter().map(|v| v.id).collect()
         } else {
-            let selected = armature.sel_bone(&sel).unwrap();
-            let sel_bind = &selected.binds;
-            verts = sel_bind[idx as usize].verts.iter().map(|v| v.id).collect();
-        }
+            vec![]
+        };
 
         // yellow vertex if bound
         let bound = idx != -1 && verts.contains(&(world_verts[wv].id as i32));


### PR DESCRIPTION
Fixes a crash when assigning mesh deformation binds.

Reproduction:
1. Enable Mesh Wires.
2. Select a bone with mesh deformation available.
3. Select Binds > New.
4. Click on the object/canvas.
5. SkelForm can panic with `called Option::unwrap() on a None value`.


The issue was caused by stale editor selection state: after a bind was selected, clicking empty canvas space could clear the selected bone while leaving the selected bind or bind-target mode active. Later, mesh wire rendering and bind-target selection assumed that a selected bind always had a valid selected source bone, which led to an `Option::unwrap()` panic.

Clearing the bone selection now also clears the active bind and cancels pending bind/IK target selection modes. Mesh wire rendering also checks whether the selected bone and bind still exist before using them for bind highlighting. If the state is no longer valid, it simply renders the mesh without bind highlighting instead of crashing.

Copy of my log first time this happened:

Panic: panicked at src\editor.rs:1230:53:
called `Option::unwrap()` on a `None` value
   0: std::backtrace_rs::backtrace::win64::trace
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\..\..\backtrace\src\backtrace\win64.rs:85
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2: std::backtrace::Backtrace::create
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\backtrace.rs:331
   3: std::backtrace::Backtrace::force_capture
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\backtrace.rs:312
   4: SkelForm::install_panic_handler::closure$0
             at D:\a\SkelForm\SkelForm\src\main.rs:218
   5: std::panicking::rust_panic_with_hook
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\panicking.rs:841
   6: std::panicking::begin_panic_handler::closure$0
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\panicking.rs:699
   7: std::sys::backtrace::__rust_end_short_backtrace<std::panicking::begin_panic_handler::closure_env$0,never$>
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\sys\backtrace.rs:168
   8: std::panicking::begin_panic_handler
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\panicking.rs:697
   9: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\core\src\panicking.rs:75
  10: core::panicking::panic
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\core\src\panicking.rs:145
  11: core::option::unwrap_failed
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\core\src\option.rs:2040
  12: enum2$<core::option::Option<ref_mut$<skelform_lib::shared::Bone> > >::unwrap
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\core\src\option.rs:1003
  13: skelform_lib::editor::select_bone
             at D:\a\SkelForm\SkelForm\src\editor.rs:1230
  14: skelform_lib::editor::simple_event
             at D:\a\SkelForm\SkelForm\src\editor.rs:439
  15: skelform_lib::editor::iterate_events
             at D:\a\SkelForm\SkelForm\src\editor.rs:297
  16: skelform_lib::impl$0::window_event
             at D:\a\SkelForm\SkelForm\src\lib.rs:460
  17: winit::event_loop::dispatch_event_for_app
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\event_loop.rs:642
  18: winit::event_loop::impl$6::run_app::closure$0
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\event_loop.rs:265
  19: winit::platform_impl::windows::event_loop::impl$3::run_on_demand::closure$0<tuple$<>,winit::event_loop::impl$6::run_app::closure_env$0<tuple$<>,skelform_lib::App> >
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:264
  20: alloc::boxed::impl$29::call_mut
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\alloc\src\boxed.rs:1973
  21: winit::platform_impl::windows::event_loop::runner::impl$3::call_event_handler::closure$0
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop\runner.rs:236
  22: core::panic::unwind_safe::impl$25::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\core\src\panic\unwind_safe.rs:272
  23: std::panicking::try::do_call
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\panicking.rs:589
  24: std::panicking::try
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\panicking.rs:552
  25: std::panic::catch_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\panic.rs:359
  26: winit::platform_impl::windows::event_loop::runner::EventLoopRunner<winit::platform_impl::windows::event_loop::UserEventPlaceholder>::catch_unwind<winit::platform_impl::windows::event_loop::UserEventPlaceholder,tuple$<>,winit::platform_impl::windows::event_
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop\runner.rs:173
  27: winit::platform_impl::windows::event_loop::runner::EventLoopRunner<winit::platform_impl::windows::event_loop::UserEventPlaceholder>::call_event_handler
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop\runner.rs:230
  28: winit::platform_impl::windows::event_loop::runner::EventLoopRunner<winit::platform_impl::windows::event_loop::UserEventPlaceholder>::send_event<winit::platform_impl::windows::event_loop::UserEventPlaceholder>
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop\runner.rs:210
  29: winit::platform_impl::windows::event_loop::public_window_callback_inner::closure$4
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:1282
  30: core::ops::function::FnOnce::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\core\src\ops\function.rs:250
  31: core::panic::unwind_safe::impl$25::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\core\src\panic\unwind_safe.rs:272
  32: std::panicking::try::do_call
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\panicking.rs:589
  33: std::panicking::try
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\panicking.rs:552
  34: std::panic::catch_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\panic.rs:359
  35: winit::platform_impl::windows::event_loop::runner::EventLoopRunner<winit::platform_impl::windows::event_loop::UserEventPlaceholder>::catch_unwind
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop\runner.rs:173
  36: winit::platform_impl::windows::event_loop::public_window_callback_inner
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:2462
  37: winit::platform_impl::windows::event_loop::public_window_callback
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:1098
  38: CallWindowProcW
  39: SendMessageW
  40: GetWindowDpiAwarenessContext
  41: KiUserCallbackDispatcher
  42: NtUserDispatchMessage
  43: IsWindowUnicode
  44: winit::platform_impl::windows::event_loop::EventLoop<tuple$<> >::dispatch_peeked_messages
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:419
  45: winit::platform_impl::windows::event_loop::EventLoop<tuple$<> >::run_on_demand
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:277
  46: winit::platform_impl::windows::event_loop::EventLoop<tuple$<> >::run
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\platform_impl\windows\event_loop.rs:233
  47: winit::event_loop::EventLoop<tuple$<> >::run_app
             at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\winit-0.30.12\src\event_loop.rs:265
  48: SkelForm::main
             at D:\a\SkelForm\SkelForm\src\main.rs:107
  49: core::ops::function::FnOnce::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\core\src\ops\function.rs:250
  50: std::sys::backtrace::__rust_begin_short_backtrace<enum2$<core::result::Result<tuple$<>,enum2$<winit::error::EventLoopError> > > (*)(),enum2$<core::result::Result<tuple$<>,enum2$<winit::error::EventLoopError> > > >
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc\library\std\src\sys\backtrace.rs:152
  51: main
  52: invoke_main
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  53: __scrt_common_main_seh
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  54: BaseThreadInitThunk
  55: RtlUserThreadStart
